### PR TITLE
feat: enforce dark theme

### DIFF
--- a/packages/extension-ui/src/components/themes.ts
+++ b/packages/extension-ui/src/components/themes.ts
@@ -93,15 +93,5 @@ export const themes = {
 export declare type AvailableThemes = keyof typeof themes;
 
 export function chooseTheme (): AvailableThemes {
-  const preferredTheme = localStorage.getItem('theme');
-
-  if (preferredTheme) {
-    return preferredTheme === 'dark'
-      ? 'dark'
-      : 'light';
-  }
-
-  return window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches
-    ? 'light'
-    : 'dark';
+  return 'dark';
 }


### PR DESCRIPTION
this PR consists of:
- changes in `theme.ts` to `chooseTheme()` function to always return `'dark'`
themes might be used in the future