### PR TITLE
Feat/AZCWSB 19 edit account name

### DIFF
--- a/packages/extension-ui/src/Popup/Accounts/EditAccountMenu.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/EditAccountMenu.tsx
@@ -3,7 +3,7 @@
 
 import type { ThemeProps } from '../../types';
 
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { RouteComponentProps, withRouter } from 'react-router';
 import styled from 'styled-components';
@@ -42,8 +42,8 @@ function EditAccountMenu({
   const searchParams = new URLSearchParams(search);
   const isExternal = searchParams.get('isExternal');
 
-  const foundAccount = accounts.find((account) => account.address === address);
-  const [account, setAccount] = useState(foundAccount);
+  const account = useMemo(() => accounts.find((account) => account.address === address), [accounts, address]);
+
   const [isHidden, setIsHidden] = useState(account?.isHidden);
 
   const chain = useMetadata(account?.genesisHash, true);
@@ -59,35 +59,22 @@ function EditAccountMenu({
   const _toggleVisibility = useCallback((): void => {
     if (address) {
       showAccount(address, isHidden || false)
-        .then((data) => {
-          if (account) {
-            setAccount({
-              ...account,
-              isHidden: !account.isHidden
-            });
-          }
-
-          setIsHidden(data);
+        .then(() => {
+          setIsHidden(!isHidden);
         })
         .catch(console.error);
     }
-  }, [address, isHidden, account]);
+  }, [address, isHidden]);
 
   const goTo = useCallback((path: string) => () => onAction(path), [onAction]);
-
-  useEffect(() => {
-    if (account) {
-      setAccount(foundAccount);
-    }
-  }, [account, foundAccount]);
 
   return (
     <>
       <Header
-        goToRoot
         showBackArrow
         showHelp
         text={t<string>('Edit Account')}
+        withGoToRoot
       />
       <div className={className}>
         <Identicon
@@ -127,7 +114,7 @@ function EditAccountMenu({
           toggle={
             <>
               <Switch
-                checked={!account?.isHidden || false}
+                checked={!account?.isHidden}
                 checkedLabel=''
                 onChange={_toggleVisibility}
                 uncheckedLabel=''

--- a/packages/extension-ui/src/Popup/Accounts/EditName.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/EditName.tsx
@@ -34,10 +34,6 @@ function EditName({
 
   const [editedName, setName] = useState<string | undefined | null>(account?.name);
 
-  const _onNameChange = useCallback((name: string | null): void => {
-    setName(name);
-  }, []);
-
   const _saveChanges = useCallback(async (): Promise<void> => {
     if (editedName) {
       try {
@@ -62,7 +58,7 @@ function EditName({
         <div className='name'>
           <Name
             label=' '
-            onChange={_onNameChange}
+            onChange={setName}
             value={account?.name}
           />
         </div>

--- a/packages/extension-ui/src/Popup/Accounts/EditName.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/EditName.tsx
@@ -1,0 +1,95 @@
+// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ThemeProps } from '../../types';
+
+import React, { useCallback, useContext, useState } from 'react';
+import { RouteComponentProps, withRouter } from 'react-router';
+import styled from 'styled-components';
+
+import { AccountContext, ActionContext, Address, Button, ButtonArea, VerticalSpace } from '../../components';
+import useToast from '../../hooks/useToast';
+import useTranslation from '../../hooks/useTranslation';
+import { editAccount } from '../../messaging';
+import { Header, Name } from '../../partials';
+
+interface Props extends RouteComponentProps<{ address: string }>, ThemeProps {
+  className?: string;
+}
+
+function EditName({
+  className,
+  match: {
+    params: { address }
+  }
+}: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+  const { show } = useToast();
+  const { accounts } = useContext(AccountContext);
+  const onAction = useContext(ActionContext);
+
+  const _goTo = useCallback((path: string) => () => onAction(path), [onAction]);
+
+  const account = accounts.find((account) => account.address === address);
+
+  const [editedName, setName] = useState<string | undefined | null>(account?.name);
+
+  const _onNameChange = useCallback((name: string | null): void => {
+    setName(name);
+  }, []);
+
+  const _saveChanges = useCallback(async (): Promise<void> => {
+    if (editedName) {
+      try {
+        await editAccount(address, editedName);
+        onAction(`/account/edit-menu/${address}`);
+        show(t<string>('Account name changed successfully'), 'success');
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  }, [editedName, address, show, t, onAction]);
+
+  return (
+    <>
+      <Header
+        showBackArrow
+        showHelp
+        text={t<string>('Account name')}
+      />
+      <div className={className}>
+        <Address address={address} />
+        <div className='name'>
+          <Name
+            label=' '
+            onChange={_onNameChange}
+            value={account?.name}
+          />
+        </div>
+      </div>
+      <VerticalSpace />
+      <ButtonArea>
+        <Button
+          onClick={_goTo(`/account/edit-menu/${address}`)}
+          secondary
+        >
+          {t<string>('Cancel')}
+        </Button>
+        <Button
+          isDisabled={!editedName}
+          onClick={_saveChanges}
+        >
+          {t<string>('Save')}
+        </Button>
+      </ButtonArea>
+    </>
+  );
+}
+
+export default withRouter(
+  styled(EditName)`
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+`
+);

--- a/packages/extension-ui/src/Popup/Forget.tsx
+++ b/packages/extension-ui/src/Popup/Forget.tsx
@@ -8,7 +8,7 @@ import { RouteComponentProps, withRouter } from 'react-router';
 import styled from 'styled-components';
 
 import helpIcon from '../assets/help.svg';
-import { ActionContext, Address, Button, ButtonArea, VerticalSpace } from '../components';
+import { ActionContext, Address, Button, ButtonArea, HelperFooter, VerticalSpace } from '../components';
 import useTranslation from '../hooks/useTranslation';
 import { forgetAccount } from '../messaging';
 import { Header } from '../partials';
@@ -42,48 +42,6 @@ function Forget({
       });
   }, [address, onAction]);
 
-  const Helper = styled.div`
-  display: flex;
-  position: relative;
-  flex-direction: row;
-  justify-content: center;
-  align-items: flex-start;
-  gap: 12px;
-  padding-top: 0px;
-  margin-bottom: 16px;
-
-  &:before {
-  position: absolute;
-  content: '';
-  width: calc(100% - 32px);
-  border-top: 1px solid ${({ theme }: ThemeProps) => theme.boxBorderColor};
-  top: -16px;
- }
-
-  img.icon {
-    margin-top: -4px;
-    align-self: flex-start; 
-  }
-
-  span {
-    font-weight: 300;
-    font-size: 13px;
-    line-height: 130%;
-    letter-spacing: 0.06em;
-    color: ${({ theme }: ThemeProps) => theme.subTextColor};
-    align-self: flex-start;
-
-    .link {
-      color: ${({ theme }: ThemeProps) => theme.primaryColor};
-      cursor: pointer;
-
-      :hover {
-        text-decoration: underline;
-      }
-    }
-  }
-`;
-
   return (
     <>
       <Header
@@ -106,7 +64,7 @@ function Forget({
         />
       </div>
       <VerticalSpace />
-      <Helper>
+      <HelperFooter>
         <img
           className='icon'
           src={helpIcon}
@@ -120,7 +78,7 @@ function Forget({
             {` ${t<string>('Learn more')}`}
           </span>
         </span>
-      </Helper>
+      </HelperFooter>
       <ButtonArea>
         <Button
           isDisabled={isBusy}
@@ -143,9 +101,6 @@ function Forget({
 export default withRouter(
   styled(Forget)(
     ({ theme }: Props) => `
-  .actionArea {
-    padding: 10px 24px;
-  }
 
   .text-container {
     display: flex;
@@ -175,17 +130,8 @@ export default withRouter(
     }
   }
 
-  .center {
-    margin: auto;
-  }
 
-  .movedWarning {
-    margin-top: 8px;
-  }
 
-  .withMarginTop {
-    margin-top: 4px;
-  }
 `
   )
 );

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -38,6 +38,7 @@ import { buildHierarchy } from '../util/buildHierarchy';
 import AddAccountMenu from './Accounts/AddAccountMenu';
 import CreateAccountMenu from './Accounts/CreateAccountMenu';
 import EditAccountMenu from './Accounts/EditAccountMenu';
+import EditName from './Accounts/EditName';
 import AccountManagement from './AuthManagement/AccountManagement';
 import Restore from './Help/Restore';
 import SafetyLink from './Help/SafetyLink';
@@ -195,6 +196,9 @@ export default function Popup(): React.ReactElement {
                             </Route>
                             <Route path='/account/edit-menu/:address'>
                               {wrapWithErrorBoundary(<EditAccountMenu />, 'edit-menu')}
+                            </Route>
+                            <Route path='/account/edit-name/:address'>
+                              {wrapWithErrorBoundary(<EditName />, 'edit-name')}
                             </Route>
                             <Route path='/account/forget/:address'>
                               {wrapWithErrorBoundary(<Forget />, 'forget-address')}

--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -417,7 +417,7 @@ export default styled(Address)(
     text-overflow: ellipsis;
     width: 300px;
     white-space: nowrap;
-    color: ${isHidden ? theme.textColor : theme.subTextColor};
+    color: ${isHidden ? theme.subTextColor : theme.textColor};
     opacity: ${isHidden ? 0.6 : 1};
   } 
 

--- a/packages/extension-ui/src/components/Button.tsx
+++ b/packages/extension-ui/src/components/Button.tsx
@@ -71,7 +71,7 @@ export default styled(Button)(
       ? theme.buttonTertiaryBackground
       : theme.buttonBackground
   };
-
+  
   cursor: pointer;
   display: block;
   width: ${tertiary ? 'max-content' : '100%'};
@@ -90,10 +90,11 @@ export default styled(Button)(
   position: relative;
   text-align: center;
   letter-spacing: 0.05em;
-  transition: .4s ease-in-out;
+  transition: .2s ease-in-out;
 
   &:disabled {
     cursor: default;
+    pointer-events: none;
     background: ${
       isDanger
         ? theme.buttonBackgroundDangerDisabled
@@ -106,7 +107,7 @@ export default styled(Button)(
     opacity: ${secondary || tertiary ? theme.buttonTertiaryDisabledOpacity : 1};
   }
 
-  &:focus{
+  &:focus {
     outline: none;
     border: ${
       secondary ? theme.buttonSecondaryBorderFocused : tertiary ? theme.buttonTertiaryBorder : theme.buttonBorderFocused

--- a/packages/extension-ui/src/components/ButtonArea.tsx
+++ b/packages/extension-ui/src/components/ButtonArea.tsx
@@ -24,7 +24,7 @@ export default styled(ButtonArea)(
   margin-right: 0;
 
   & > button:not(:last-of-type) {
-    margin-right: 8px;
+    margin-right: 16px;
   }
 `
 );

--- a/packages/extension-ui/src/components/EditMenuCard.tsx
+++ b/packages/extension-ui/src/components/EditMenuCard.tsx
@@ -89,6 +89,7 @@ export default styled(EditMenuCard)(
   border-radius: 8px;
   height: 48px;
   margin-bottom: ${position === 'top' || position === 'middle' ? ' 2px' : '16px'};
+  margin-top: ${position === 'both' ? '16px' : '0px'}
   border-radius: ${
     position === 'top'
       ? '8px 8px 2px 2px'

--- a/packages/extension-ui/src/components/InputWithLabel.tsx
+++ b/packages/extension-ui/src/components/InputWithLabel.tsx
@@ -77,10 +77,10 @@ export default styled(InputWithLabel)(
   ({ label }: Props) => `
   margin-bottom: 16px;
  
-  > ${Input}{
+  > ${Input} {
   padding-top: ${!label.trim() ? '0px' : '8px'};
  }
- 
+
   &.withoutMargin {
     margin-bottom: 0px;
 

--- a/packages/extension-ui/src/components/InputWithLabel.tsx
+++ b/packages/extension-ui/src/components/InputWithLabel.tsx
@@ -59,6 +59,7 @@ function InputWithLabel({
         autoFocus={isFocused}
         defaultValue={defaultValue || undefined}
         disabled={disabled}
+        emptyLabel={label === ' '}
         onBlur={onBlur}
         onChange={_onChange}
         placeholder={placeholder}

--- a/packages/extension-ui/src/components/InputWithLabel.tsx
+++ b/packages/extension-ui/src/components/InputWithLabel.tsx
@@ -4,10 +4,11 @@
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
 
+import { ThemeProps } from '../types';
 import Label from './Label';
 import { Input } from './TextInputs';
 
-interface Props {
+interface Props extends ThemeProps {
   className?: string;
   defaultValue?: string | null;
   disabled?: boolean;
@@ -59,7 +60,6 @@ function InputWithLabel({
         autoFocus={isFocused}
         defaultValue={defaultValue || undefined}
         disabled={disabled}
-        emptyLabel={label === ' '}
         onBlur={onBlur}
         onChange={_onChange}
         placeholder={placeholder}
@@ -73,9 +73,14 @@ function InputWithLabel({
   );
 }
 
-export default styled(InputWithLabel)`
+export default styled(InputWithLabel)(
+  ({ label }: Props) => `
   margin-bottom: 16px;
-
+ 
+  > ${Input}{
+  padding-top: ${!label.trim() ? '0px' : '8px'};
+ }
+ 
   &.withoutMargin {
     margin-bottom: 0px;
 
@@ -83,4 +88,5 @@ export default styled(InputWithLabel)`
       margin-top: 6px;
     }
   }
-`;
+`
+);

--- a/packages/extension-ui/src/components/TextInputs.ts
+++ b/packages/extension-ui/src/components/TextInputs.ts
@@ -7,10 +7,11 @@ import styled, { css } from 'styled-components';
 
 interface Props extends ThemeProps {
   withError?: boolean;
+  emptyLabel?: boolean;
 }
 
 const TextInput = css(
-  ({ theme, withError }: Props) => `
+  ({ emptyLabel = false, theme, withError }: Props) => `
   background: ${theme.inputBackground};
   border-radius: 2px;
   border: 1px solid ${theme.inputBorderColor};
@@ -22,7 +23,7 @@ const TextInput = css(
   font-size: ${theme.fontSize};
   height: 56px;
   outline: none;
-  padding-top: 8px;
+  padding-top: ${emptyLabel ? '0px' : '8px'};
   padding-left: 12px;
   resize: none;
   width: 100%;

--- a/packages/extension-ui/src/components/TextInputs.ts
+++ b/packages/extension-ui/src/components/TextInputs.ts
@@ -7,11 +7,10 @@ import styled, { css } from 'styled-components';
 
 interface Props extends ThemeProps {
   withError?: boolean;
-  emptyLabel?: boolean;
 }
 
 const TextInput = css(
-  ({ emptyLabel = false, theme, withError }: Props) => `
+  ({ theme, withError }: Props) => `
   background: ${theme.inputBackground};
   border-radius: 2px;
   border: 1px solid ${theme.inputBorderColor};
@@ -23,7 +22,6 @@ const TextInput = css(
   font-size: ${theme.fontSize};
   height: 56px;
   outline: none;
-  padding-top: ${emptyLabel ? '0px' : '8px'};
   padding-left: 12px;
   resize: none;
   width: 100%;

--- a/packages/extension-ui/src/components/Toast/Toast.tsx
+++ b/packages/extension-ui/src/components/Toast/Toast.tsx
@@ -14,6 +14,7 @@ interface Props extends ThemeProps {
   content: React.ReactNode;
   className?: string;
   type: SnackbarTypes;
+  visible: boolean;
 }
 
 function Toast({ className, content, type }: Props): React.ReactElement<Props> {
@@ -35,9 +36,10 @@ function Toast({ className, content, type }: Props): React.ReactElement<Props> {
   );
 }
 
-export default styled(Toast)<{ visible: boolean }>`
+export default styled(Toast)(
+  ({ theme, type, visible }: Props) => `
   position: fixed;
-  display: ${({ visible }): string => (visible ? 'flex' : 'none')};
+  display: ${visible ? 'flex' : 'none'};
   height: 72px;
   bottom: 8px;
   left: 8px;
@@ -45,15 +47,15 @@ export default styled(Toast)<{ visible: boolean }>`
   flex-direction: row;
   align-items: center;
   border-radius: 4px;
-  box-shadow: ${({ theme }: Props): string => theme.toastBoxShadow};;
+  box-shadow: ${theme.toastBoxShadow};;
   gap: 14px;
-  color : ${({ theme }: Props): string => theme.toastTextColor};
+  color : ${theme.toastTextColor};
   isolation: isolate;
   width: 344px;
   padding: 16px;
   box-sizing: border-box;
   animation: toast 0.2s, toast  0.2s linear 1.4s reverse;
-
+  
   @keyframes toast {
   from {
     opacity: 0;
@@ -67,7 +69,7 @@ export default styled(Toast)<{ visible: boolean }>`
 
   .snackbar-content {
     min-width: 200px;
-    font-family:  ${({ theme }: Props): string => theme.secondaryFontFamily};
+    font-family:  ${theme.secondaryFontFamily};
     font-weight: 500;
     font-size: 14px;
     line-height: 120%;
@@ -76,14 +78,16 @@ export default styled(Toast)<{ visible: boolean }>`
 
   && {
     border-radius: 4px;
-    background: ${({ theme, type }: Props): string =>
+    background: ${
       type === 'success'
         ? theme.toastSuccessBackground
         : type === 'warning'
         ? theme.toastWarningBackground
         : type === 'critical'
         ? theme.toastCriticalBackground
-        : theme.toastInfoBackground};
+        : theme.toastInfoBackground
+    };
   }
-  
-`;
+
+`
+);

--- a/packages/extension-ui/src/components/Toast/Toast.tsx
+++ b/packages/extension-ui/src/components/Toast/Toast.tsx
@@ -67,6 +67,11 @@ export default styled(Toast)<{ visible: boolean }>`
 
   .snackbar-content {
     min-width: 200px;
+    font-family:  ${({ theme }: Props): string => theme.secondaryFontFamily};
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 120%;
+    letter-spacing: 0.07em;
   }
 
   && {

--- a/packages/extension-ui/src/partials/Header.tsx
+++ b/packages/extension-ui/src/partials/Header.tsx
@@ -32,20 +32,20 @@ interface Props extends ThemeProps {
   smallMargin?: boolean;
   text?: React.ReactNode;
   withStepper?: boolean;
-  goToRoot?: boolean;
+  withGoToRoot?: boolean;
 }
 
 function Header({
   children,
   className = '',
   // onFilter,
-  goToRoot = false,
-  // showConnectedAccounts,
   showBackArrow,
+  // showConnectedAccounts,
   showHelp,
   showSettings,
   smallMargin = false,
   text,
+  withGoToRoot = false,
   withStepper = false
 }: Props): React.ReactElement<Props> {
   const [isAddOpen, setShowAdd] = useState(false);
@@ -114,7 +114,7 @@ function Header({
             <FontAwesomeIcon
               className='arrowLeftIcon'
               icon={faArrowLeft}
-              onClick={goToRoot ? _goToRoot : _onBackArrowClick}
+              onClick={withGoToRoot ? _goToRoot : _onBackArrowClick}
             />
           ) : (
             <div className='flex'>

--- a/packages/extension-ui/src/partials/Header.tsx
+++ b/packages/extension-ui/src/partials/Header.tsx
@@ -32,14 +32,16 @@ interface Props extends ThemeProps {
   smallMargin?: boolean;
   text?: React.ReactNode;
   withStepper?: boolean;
+  goToRoot?: boolean;
 }
 
 function Header({
   children,
   className = '',
   // onFilter,
-  showBackArrow,
+  goToRoot = false,
   // showConnectedAccounts,
+  showBackArrow,
   showHelp,
   showSettings,
   smallMargin = false,
@@ -102,6 +104,7 @@ function Header({
   // }, [_onChangeFilter, isSearchOpen]);
 
   const _onBackArrowClick = useCallback(() => onAction('..'), [onAction]);
+  const _goToRoot = useCallback(() => onAction('/'), [onAction]);
 
   return (
     <div className={`${className} ${smallMargin ? 'smallMargin' : ''} header`}>
@@ -111,7 +114,7 @@ function Header({
             <FontAwesomeIcon
               className='arrowLeftIcon'
               icon={faArrowLeft}
-              onClick={_onBackArrowClick}
+              onClick={goToRoot ? _goToRoot : _onBackArrowClick}
             />
           ) : (
             <div className='flex'>

--- a/packages/extension-ui/src/partials/HeaderWithSteps.tsx
+++ b/packages/extension-ui/src/partials/HeaderWithSteps.tsx
@@ -31,7 +31,7 @@ const Step = styled.div<StepProps>`
 const Steps = styled.div`
   display: flex;
   justify-content: center;
-  margin: 8px -16px 0;
+  margin: 0px -16px 0;
   gap: 8px;
 
   :first-child {

--- a/packages/extension/public/locales/bn/translation.json
+++ b/packages/extension/public/locales/bn/translation.json
@@ -201,5 +201,9 @@
     "Visibility for apps": "",
     "Address": "",
     "Public address copied to your clipboard": "",
-    "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": ""
+    "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": "",
+    "Account name": "",
+    "Save": "",
+    "This name is visible only on this device.": "",
+    "Account name changed successfully": ""
 }

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -215,5 +215,9 @@
   "Visibility for apps": "",
   "Address": "",
   "Public address copied to your clipboard": "",
-  "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": ""
+  "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": "",
+  "Account name": "",
+  "Save": "",
+  "This name is visible only on this device.": "",
+  "Account name changed successfully": ""
 }

--- a/packages/extension/public/locales/fr/translation.json
+++ b/packages/extension/public/locales/fr/translation.json
@@ -196,5 +196,9 @@
   "Visibility for apps": "",
   "Address": "",
   "Public address copied to your clipboard": "",
-  "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": ""
+  "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": "",
+  "Account name": "",
+  "Save": "",
+  "This name is visible only on this device": "",
+  "Account name changed successfully": ""
 }

--- a/packages/extension/public/locales/pl/translation.json
+++ b/packages/extension/public/locales/pl/translation.json
@@ -201,5 +201,9 @@
 	"Visibility for apps": "",
 	"Address": "",
 	"Public address copied to your clipboard": "",
-	"Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": ""
+	"Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": "",
+	"Account name": "",
+	"Save": "",
+	"This name is visible only on this device.": "",
+	"Account name changed successfully": ""
 }

--- a/packages/extension/public/locales/th/translation.json
+++ b/packages/extension/public/locales/th/translation.json
@@ -201,5 +201,9 @@
   "Visibility for apps": "",
   "Address": "",
   "Public address copied to your clipboard": "",
-  "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": ""
+  "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": "",
+  "Account name": "",
+  "Save": "",
+  "This name is visible only on this device.": "",
+  "Account name changed successfully": ""
 }

--- a/packages/extension/public/locales/tr/translation.json
+++ b/packages/extension/public/locales/tr/translation.json
@@ -201,5 +201,9 @@
   "Visibility for apps": "",
   "Address": "",
   "Public address copied to your clipboard": "",
-  "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": ""
+  "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": "",
+  "Account name": "",
+  "Save": "",
+  "This name is visible only on this device.": "",
+  "Account name changed successfully": ""
 }

--- a/packages/extension/public/locales/ur/translation.json
+++ b/packages/extension/public/locales/ur/translation.json
@@ -199,5 +199,9 @@
     "Visibility for apps": "",
     "Address": "",
     "Public address copied to your clipboard": "",
-    "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": ""
+    "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": "",
+    "Account name": "",
+    "Save": "",
+    "This name is visible only on this device.": "",
+    "Account name changed successfully": ""
 }

--- a/packages/extension/public/locales/zh/translation.json
+++ b/packages/extension/public/locales/zh/translation.json
@@ -143,5 +143,9 @@
   "Visibility for apps": "",
   "Address": "",
   "Public address copied to your clipboard": "",
-  "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": ""
+  "Even though you can remove account from this wallet, you can restore it here or in another wallet with the secret phrase.": "",
+  "Account name": "",
+  "Save": "",
+  "This name is visible only on this device.": "",
+  "Account name changed successfully": ""
 }


### PR DESCRIPTION
This PR consists of:
- adding `translations`
- creating `EditName`
- adjusting `Button`, `ButtonArea`, `Toast`, `Forget
- implementing `goToRoot` optional prop for header
- adding new `edit-name` route