### PR TITLE
fix: fixed wrong derive address

### DIFF
--- a/packages/extension-ui/src/Popup/Accounts/EditAccountMenu.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/EditAccountMenu.tsx
@@ -139,7 +139,7 @@ function EditAccountMenu({
           <EditMenuCard
             description=''
             extra='chevron'
-            onClick={goTo(`/account/derive/${master.address}/locked`)}
+            onClick={goTo(`/account/derive/${address}/locked`)}
             position='both'
             preIcon={
               <Svg


### PR DESCRIPTION
`Derive` was using `master.adress` instead of the provided one