### PR TITLE
fix: URL origin as object key  in localStorage

### DIFF
--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -238,7 +238,9 @@ export default class State {
     const complete = (authorizedAccounts: string[] = []) => {
       const { idStr, request: { origin }, url } = this.#authRequests[id];
 
-      this.#authUrls[decodeURIComponent(url)] = {
+      const URLorigin = new URL(url).origin;
+
+      this.#authUrls[URLorigin] = {
         authorizedAccounts,
         count: 0,
         id: idStr,


### PR DESCRIPTION
Changed the localstorage key to use URL origin instead of the URL itself to avoid multiple connection calls for the same website